### PR TITLE
Allow custom inputs chunking and titles steps

### DIFF
--- a/discord/ext/modal_paginator/core.py
+++ b/discord/ext/modal_paginator/core.py
@@ -513,7 +513,7 @@ class ModalPaginator(discord.ui.View):
             The constructed paginator with the modals.
         """
 
-        if titles_steps < 0 or ((titles_steps > len(titles)) if not isinstance(titles, str) else True):
+        if titles_steps < 0 or ((titles_steps > len(titles)) if not isinstance(titles, str) else False):
             raise ValueError('titles_step must be between 0 and the length of the titles, if available')
 
         if max_inputs_per_modal < 1 or max_inputs_per_modal > 5:

--- a/discord/ext/modal_paginator/core.py
+++ b/discord/ext/modal_paginator/core.py
@@ -499,6 +499,7 @@ class ModalPaginator(discord.ui.View):
             .. versionadded:: 1.3
         titles_step: :class:`int`
             How much indexes should the modal increase per each modal created.
+            Defaults to ``1``.
 
             .. versionadded:: 1.3
 

--- a/discord/ext/modal_paginator/core.py
+++ b/discord/ext/modal_paginator/core.py
@@ -514,7 +514,7 @@ class ModalPaginator(discord.ui.View):
         """
 
         if titles_steps < 0 or ((titles_steps > len(titles)) if not isinstance(titles, str) else True):
-            raise ValueError('titles_step must be between 0 and the length of the titles, if available')
+            raise ValueError('titles_step must be between 0 and the length of the titles ({len(titles)}), if available')
 
         if max_inputs_per_modal < 1 or max_inputs_per_modal > 5:
             raise ValueError('max_inputs_per_modal must be between 1 and 5, both included')

--- a/discord/ext/modal_paginator/core.py
+++ b/discord/ext/modal_paginator/core.py
@@ -430,6 +430,8 @@ class ModalPaginator(discord.ui.View):
         buttons: Optional[CustomButtons] = None,
         titles: Union[str, Sequence[str]] = discord.utils.MISSING,
         default_title: str = "Enter your input",
+        max_inputs_per_modal: int = 5,
+        titles_steps: int = 1,
     ) -> ModalPaginator:
         """A shortcut method to create a :class:`ModalPaginator` with a list of text inputs.
 
@@ -490,6 +492,15 @@ class ModalPaginator(discord.ui.View):
                     default_title="Please answer the following questions",
                     # other parameters
                 )
+        max_inputs_per_modal: :class:`int`
+            The maximum inputs to add per each modal created. Must be between 1 and 5,
+            both included. Defaults to ``5``.
+
+            .. versionadded:: 1.3
+        titles_step: :class:`int`
+            How much indexes should the modal increase per each modal created.
+
+            .. versionadded:: 1.3
 
 
         Other parameters are the same as :class:`ModalPaginator`.
@@ -515,7 +526,7 @@ class ModalPaginator(discord.ui.View):
                 return default_title
 
         modals: List[PaginatorModal] = []
-        for idx, text_inputs in enumerate(discord.utils.as_chunks(inputs, 5)):
+        for idx, text_inputs in utils.step_enumerate(discord.utils.as_chunks(inputs, max_inputs_per_modal), 0, titles_steps):
             constructed_inputs: List[discord.ui.TextInput[Any]] = [
                 (inp if isinstance(inp, discord.ui.TextInput) else discord.ui.TextInput(label=inp))
                 for inp in text_inputs

--- a/discord/ext/modal_paginator/core.py
+++ b/discord/ext/modal_paginator/core.py
@@ -513,6 +513,12 @@ class ModalPaginator(discord.ui.View):
             The constructed paginator with the modals.
         """
 
+        if titles_steps < 0 or ((titles_steps > len(titles)) if not isinstance(titles, str) else True):
+            raise ValueError('titles_step must be between 0 and the length of the titles, if available')
+
+        if max_inputs_per_modal < 1 or max_inputs_per_modal > 5:
+            raise ValueError('max_inputs_per_modal must be between 1 and 5, both included')
+
         def get_title(idx: int) -> str:
             if titles is discord.utils.MISSING:
                 return default_title

--- a/discord/ext/modal_paginator/utils.py
+++ b/discord/ext/modal_paginator/utils.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
+from typing import Any, Generator, Generic, Iterable, Iterator, Tuple, TypeVar
+
 import discord
+
+T = TypeVar('T')
 
 
 IS_DPY2_5 = discord.version_info >= (2, 5, 0)
@@ -6,3 +12,51 @@ IS_DPY2_5 = discord.version_info >= (2, 5, 0)
 # https://canary.discord.com/channels/336642139381301249/1341405833640022098
 # https://github.com/Rapptz/discord.py/issues/10107
 IS_DPY_2_5_WITH_INTERACTIONEDITFIXED = discord.version_info >= (2, 5, 1)
+
+
+class step_enumerate(Generic[T]):
+    """A class that simulates :class:`enumerate`, but allows passing a custom
+    step to increment the enumeration.
+
+    .. versionadded:: 1.3
+
+    Parameters
+    ----------
+    iterable: Iterable[Any]
+        The iterable to enumerate.
+    start: :class:`int`
+        Where should the count start. Defaults to ``0``.
+    step: :class:`int`
+        How much should the count increment every time an item is returned.
+        Defaults to ``1``.
+    """
+
+    __slots__ = (
+        '_iterable',
+        'start',
+        'step',
+    )
+
+    def __init__(self, iterable: Iterable[T], start: int = 0, step: int = 1) -> None:
+        self._iterable: Iterable[T] = iterable
+        self.start: int = start
+        self.step: int = step
+
+    def enumerate(self) -> Generator[Tuple[int, T], Any, None]:
+        """An iterator that yields a tuple of ``(pos, item)`` pair.
+
+        Yields
+        ------
+        Tuple[:class:`int`, Any]
+            The (pos, item) pairs.
+        """
+
+        pos = self.start
+
+        for item in self._iterable:
+            yield (pos, item)
+
+            pos += self.step
+
+    def __iter__(self) -> Iterator[Tuple[int, T]]:
+        return iter(self.enumerate())


### PR DESCRIPTION
Allows users to customize the amount of items that each modal should have on ``ModalPaginator.from_text_inputs``.